### PR TITLE
Store queue capacity in shared memory state

### DIFF
--- a/dejaq/queues.py
+++ b/dejaq/queues.py
@@ -244,16 +244,19 @@ class NamedByteRing:
         base = name or _safe_base("nq")
         self._base = base
         self._auto_unlink = bool(auto_unlink)
-        # Shared state: head, tail, n_items, closed (0/1)
+        # Shared state: head, tail, n_items, closed (0/1), cap
         st_name = ("NS_" + base) if _IS_WIN else base + "_S"
         self._owns = create
         if create:
-            self._state_mem = shared_memory.SharedMemory(create=True, name=st_name, size=8 * 4)
+            self._state_mem = shared_memory.SharedMemory(create=True, name=st_name, size=8 * 5)
         else:
             self._state_mem = shared_memory.SharedMemory(name=st_name)
         self._state = self._state_mem.buf.cast("q")
         if create:
-            self._state[0:4] = array.array("q", [0, 0, 0, 0])
+            self._state[0:5] = array.array("q", [0, 0, 0, 0, buffer_bytes])
+            self.cap = buffer_bytes
+        else:
+            self.cap = int(self._state[4])  # read cap stored by the creator
         self._state_name = st_name
 
         # Data buffer
@@ -264,7 +267,6 @@ class NamedByteRing:
             _view[:] = 0
         else:
             self.buf = shared_memory.SharedMemory(name=buf_name, create=False)
-        self.cap = self.buf.size  # use actual mapped size, not the parameter
         self._buf_name = buf_name
 
         # Sync: serialize producers/consumers + count items + wake producers

--- a/dejaq/queues.py
+++ b/dejaq/queues.py
@@ -258,13 +258,13 @@ class NamedByteRing:
 
         # Data buffer
         buf_name = ("NB_" + base) if _IS_WIN else base + "_B"
-        self.cap = buffer_bytes
         if create:
             self.buf = shared_memory.SharedMemory(name=buf_name, create=True, size=buffer_bytes)
             _view = np.frombuffer(self.buf.buf, dtype="B", count=buffer_bytes)
             _view[:] = 0
         else:
             self.buf = shared_memory.SharedMemory(name=buf_name, create=False)
+        self.cap = self.buf.size  # use actual mapped size, not the parameter
         self._buf_name = buf_name
 
         # Sync: serialize producers/consumers + count items + wake producers

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -20,9 +20,21 @@ import cloudpickle
 
 from .queues import DejaQueue
 
-logging.basicConfig(
-    level=logging.INFO, format="%(processName)s %(levelname)s: %(message)s", stream=sys.stdout, force=True
-)
+def _configure_logging():
+    handlers = []
+    for stream in (sys.stdout, sys.stderr):
+        if stream is not None:
+            handlers.append(logging.StreamHandler(stream))
+    if not handlers:
+        handlers.append(logging.NullHandler())
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(processName)s %(levelname)s: %(message)s",
+        handlers=handlers,
+        force=True,
+    )
+
+_configure_logging()
 
 
 @dataclass
@@ -72,19 +84,26 @@ class RemoteError(RuntimeError):
 
 
 # ============================== Server/worker loops ==============================
-def _actor_server(pkl: bytes) -> None:
+def _actor_server(pkl: bytes, ready_q=None) -> None:
     """Actor loop: instantiates `cls` and services _Req from a request queue.
 
     The server replies to the mailbox specified by each request's `reply`
     (skipped entirely if `reply` is None). Designed to be module-level for Windows 'spawn'.
     """
-    cls, actor_args, actor_kwargs, req_name = cloudpickle.loads(pkl)
-    req = DejaQueue(name=req_name, create=False)
+    try:
+        cls, actor_args, actor_kwargs, req_name = cloudpickle.loads(pkl)
+        req = DejaQueue(name=req_name, create=False)
 
-    if isinstance(cls, ModuleType):
-        obj = cls
-    else:
-        obj = cls(*actor_args, **actor_kwargs)
+        if isinstance(cls, ModuleType):
+            obj = cls
+        else:
+            obj = cls(*actor_args, **actor_kwargs)
+    except BaseException:
+        tb = traceback.format_exc()
+        logging.error(f"Actor server failed to start:\n{tb}")
+        if ready_q is not None:
+            ready_q.put(tb)
+        return
 
     cls_name = (
         cls.__wrapped__.__name__
@@ -92,6 +111,8 @@ def _actor_server(pkl: bytes) -> None:
         else (cls.__name__ if hasattr(cls, "__name__") else repr(cls))
     )
 
+    if ready_q is not None:
+        ready_q.put(None)  # signal successful startup to parent
     logging.info(f"Actor server started. ID: {req_name}, instance: {cls_name}")
 
     rep_cache: Dict[str, DejaQueue] = {}
@@ -385,9 +406,13 @@ class Actor:
         self._mbox = _Mailbox(self._rep)
         self._req = DejaQueue(buffer_bytes=buffer_bytes, name=base + "_req", create=True)  # requests
         ctx = mp.get_context(start_method)
+        ready_q = ctx.SimpleQueue()
         pkl = cloudpickle.dumps((cls, args, kwargs, self._req._base))
-        ps = [ctx.Process(target=_actor_server, args=(pkl,), daemon=True) for _ in range(1)]
+        ps = [ctx.Process(target=_actor_server, args=(pkl, ready_q), daemon=True) for _ in range(1)]
         [p.start() for p in ps]
+        result = ready_q.get()  # blocks until server signals ready or startup failure
+        if result is not None:
+            raise RuntimeError(f"Actor failed to start:\n{result}")
         self._proc_meta = [{"pid": p.pid, "create_time": psutil.Process(p.pid).create_time()} for p in ps]
         self._cache = {}  # Cache for resolved remote methods/attributes
         self._cls_name = cls.__wrapped__.__name__ if hasattr(cls, "__wrapped__") else (cls.__name__ if hasattr(cls, "__name__") else repr(cls))

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -20,21 +20,9 @@ import cloudpickle
 
 from .queues import DejaQueue
 
-def _configure_logging():
-    handlers = []
-    for stream in (sys.stdout, sys.stderr):
-        if stream is not None:
-            handlers.append(logging.StreamHandler(stream))
-    if not handlers:
-        handlers.append(logging.NullHandler())
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(processName)s %(levelname)s: %(message)s",
-        handlers=handlers,
-        force=True,
-    )
-
-_configure_logging()
+logging.basicConfig(
+    level=logging.INFO, format="%(processName)s %(levelname)s: %(message)s", stream=sys.stdout, force=True
+)
 
 
 @dataclass
@@ -84,26 +72,19 @@ class RemoteError(RuntimeError):
 
 
 # ============================== Server/worker loops ==============================
-def _actor_server(pkl: bytes, ready_q=None) -> None:
+def _actor_server(pkl: bytes) -> None:
     """Actor loop: instantiates `cls` and services _Req from a request queue.
 
     The server replies to the mailbox specified by each request's `reply`
     (skipped entirely if `reply` is None). Designed to be module-level for Windows 'spawn'.
     """
-    try:
-        cls, actor_args, actor_kwargs, req_name = cloudpickle.loads(pkl)
-        req = DejaQueue(name=req_name, create=False)
+    cls, actor_args, actor_kwargs, req_name = cloudpickle.loads(pkl)
+    req = DejaQueue(name=req_name, create=False)
 
-        if isinstance(cls, ModuleType):
-            obj = cls
-        else:
-            obj = cls(*actor_args, **actor_kwargs)
-    except BaseException:
-        tb = traceback.format_exc()
-        logging.error(f"Actor server failed to start:\n{tb}")
-        if ready_q is not None:
-            ready_q.put(tb)
-        return
+    if isinstance(cls, ModuleType):
+        obj = cls
+    else:
+        obj = cls(*actor_args, **actor_kwargs)
 
     cls_name = (
         cls.__wrapped__.__name__
@@ -111,8 +92,6 @@ def _actor_server(pkl: bytes, ready_q=None) -> None:
         else (cls.__name__ if hasattr(cls, "__name__") else repr(cls))
     )
 
-    if ready_q is not None:
-        ready_q.put(None)  # signal successful startup to parent
     logging.info(f"Actor server started. ID: {req_name}, instance: {cls_name}")
 
     rep_cache: Dict[str, DejaQueue] = {}
@@ -406,13 +385,9 @@ class Actor:
         self._mbox = _Mailbox(self._rep)
         self._req = DejaQueue(buffer_bytes=buffer_bytes, name=base + "_req", create=True)  # requests
         ctx = mp.get_context(start_method)
-        ready_q = ctx.SimpleQueue()
         pkl = cloudpickle.dumps((cls, args, kwargs, self._req._base))
-        ps = [ctx.Process(target=_actor_server, args=(pkl, ready_q), daemon=True) for _ in range(1)]
+        ps = [ctx.Process(target=_actor_server, args=(pkl,), daemon=True) for _ in range(1)]
         [p.start() for p in ps]
-        result = ready_q.get()  # blocks until server signals ready or startup failure
-        if result is not None:
-            raise RuntimeError(f"Actor failed to start:\n{result}")
         self._proc_meta = [{"pid": p.pid, "create_time": psutil.Process(p.pid).create_time()} for p in ps]
         self._cache = {}  # Cache for resolved remote methods/attributes
         self._cls_name = cls.__wrapped__.__name__ if hasattr(cls, "__wrapped__") else (cls.__name__ if hasattr(cls, "__name__") else repr(cls))


### PR DESCRIPTION
## Summary
This change modifies the shared memory state management to persist the queue's buffer capacity (`cap`) across processes, ensuring all processes accessing the queue can read the same capacity value.

## Key Changes
- Expanded shared memory state from 4 to 5 long integers to include the `cap` field
- Updated state memory allocation size from `8 * 4` to `8 * 5` bytes
- Modified state initialization to store `buffer_bytes` in `self._state[4]`
- Changed capacity assignment logic:
  - Creator process: sets `self.cap = buffer_bytes` during initialization
  - Non-creator processes: reads `self.cap` from shared state (`self._state[4]`)
- Moved `self.cap` assignment from a single location to process-specific initialization paths

## Implementation Details
The capacity is now part of the shared state array, allowing non-creator processes to access the queue's buffer capacity without needing to pass it separately. This ensures consistency across all processes that attach to the same queue.

https://claude.ai/code/session_01S3pZJHih4Pu6D3afUodE6Y