### PR TITLE
actor server: zero-copy dispatch via callback, warn on retained shared-memory arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ greeter.close()
 - **Remote method calls:** Call methods as if the object was local.
 - **Remote attribute access:** Get/set attributes of the remote object.
 - **Async support:** Call `method_async()` to get a `Future` for non-blocking calls.
-- **Zero-copy fast path:** Pass `deepcopy=False` to skip the default deep-copy of numpy array arguments (e.g. `actor.process(arr, deepcopy=False)`). The remote method then operates on numpy arrays viewing shared memory directly; a `RuntimeWarning` is emitted if any input array is retained beyond the call.
+- **Zero-copy fast path:** Pass `deepcopy=False` to skip the default deep-copy of numpy array arguments (e.g. `actor.process(arr, deepcopy=False)`). The remote method then operates on numpy arrays viewing shared memory directly — they are only valid for the duration of the call. **Do not** store them (`self.foo = arr`), return them, hand them to async/background work, or otherwise retain a reference: the underlying buffer is reused by the queue once the call returns and any retained view will be silently overwritten. If you need to keep the data, call `arr.copy()` first. A `RuntimeWarning` is emitted if a retained reference is detected.
 - **Tab completion:** Works in Jupyter and most IDEs.
 
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ greeter.close()
 - **Remote method calls:** Call methods as if the object was local.
 - **Remote attribute access:** Get/set attributes of the remote object.
 - **Async support:** Call `method_async()` to get a `Future` for non-blocking calls.
+- **Zero-copy fast path:** Pass `deepcopy=False` to skip the default deep-copy of numpy array arguments (e.g. `actor.process(arr, deepcopy=False)`). The remote method then operates on numpy arrays viewing shared memory directly; a `RuntimeWarning` is emitted if any input array is retained beyond the call.
 - **Tab completion:** Works in Jupyter and most IDEs.
 
 

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -411,6 +411,10 @@ class Actor:
 
     Supports:
       • Remote method calls: `a.method(x)`, `a.method_async(x)`, `a.method(..., noreply=True)`
+      • Zero-copy dispatch via `a.method(arr, deepcopy=False)`: skip the default
+        deep-copy of args. The actor method then receives numpy arrays viewing
+        shared memory; a RuntimeWarning is emitted if any are retained beyond
+        the call.
       • Jupyter tab completion: `__dir__` merges local + remote names
 
     Args:

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -6,10 +6,12 @@ import sys
 import time
 import uuid
 import traceback
+import warnings
 import psutil
 import inspect
 import multiprocessing as mp
 import weakref
+import numpy as np
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Dict, Tuple, List
 from types import ModuleType
@@ -133,61 +135,94 @@ def _actor_server(pkl: bytes) -> None:
     signal.signal(signal.SIGTERM, lambda signum, frame: stop.set())
     signal.signal(signal.SIGINT,  lambda signum, frame: stop.set())  # protect on Windows spawn
 
-    msg: _Req | None = None
-    
-    while not stop.is_set():
+    def _dispatch(msg: _Req):
+        """Called by req.get(callback=_dispatch) while shared memory is still pinned."""
+        ok = True
+        payload = None
+        shutdown = False
+
+        # snapshot refcounts of numpy array args so we can detect retained references
+        arrays = [a for a in msg.args if isinstance(a, np.ndarray)]
+        rcs_before = []
+        for _, a in enumerate(arrays):
+            rcs_before.append(sys.getrefcount(a))
+
         try:
-            msg = None
-            try: 
-                _idle_timeout = getattr(obj, "_idle_timeout", None)
-                msg = req.get(timeout=_idle_timeout)  # blocking if _idle_timeout is None
-            except TimeoutError:
-                # if obj._idle_function is not None:
-                if getattr(obj, "_idle_function", None) is not None:
-                    res = getattr(obj, obj._idle_function)()
-                continue
             if msg.kind == "shutdown":
-                break
+                shutdown = True
             elif msg.kind == "ping":
-                out = time.time()
-                _maybe_reply(msg, _Rep(msg.call_id, True, out))
+                payload = time.time()
             elif msg.kind == "call":
-                out = getattr(obj, msg.name)(*msg.args, **msg.kwargs)
-                _maybe_reply(msg, _Rep(msg.call_id, True, out))
+                payload = getattr(obj, msg.name)(*msg.args, **msg.kwargs)
             elif msg.kind == "getattr":
-                out = getattr(obj, msg.name)
-                _maybe_reply(msg, _Rep(msg.call_id, True, out))
+                payload = getattr(obj, msg.name)
             elif msg.kind == "setattr":
                 setattr(obj, msg.name, msg.kwargs.get("value"))
-                _maybe_reply(msg, _Rep(msg.call_id, True, True))
-            elif msg.kind == "resolve":  # classify *without* invoking descriptors/properties
+                payload = True
+            elif msg.kind == "resolve":
                 try:
                     v = inspect.getattr_static(obj, msg.name)
                 except AttributeError:
-                    try:  # Fallback to the unwrapped target (common for proxies)
+                    try:
                         v = inspect.getattr_static(inspect.unwrap(obj), msg.name)
                     except AttributeError:
-                        out = {"exists": False, "callable": False}
-                        _maybe_reply(msg, _Rep(msg.call_id, True, out))
-                        continue
+                        payload = {"exists": False, "callable": False}
+                        return msg.call_id, msg.reply, ok, payload, shutdown
                 if isinstance(v, (staticmethod, classmethod)):
                     v = v.__func__
                 is_prop = isinstance(v, property)
-                out = {
+                payload = {
                     "exists": True,
                     "callable": (callable(v) and not is_prop),
                     "signature": inspect.signature(v) if callable(v) else None,
                 }
-                _maybe_reply(msg, _Rep(msg.call_id, True, out))
             elif msg.kind == "dir":
-                out = _dir_payload()
-                _maybe_reply(msg, _Rep(msg.call_id, True, out))
+                payload = _dir_payload()
             else:
                 raise ValueError(f"unknown kind {msg.kind!r}")
         except BaseException as e:
             logging.error(f"Actor server caught: {type(e).__name__}{e.args}\n{traceback.format_exc()}")
-            if msg is not None and msg.reply is not None:
-                _maybe_reply(msg, _Rep(msg.call_id, False, (type(e).__name__, e.args, traceback.format_exc())))
+            ok = False
+            payload = (type(e).__name__, e.args, traceback.format_exc())
+
+        # warn if the user method retained a reference to a shared-memory-backed array
+        for i, a in enumerate(arrays):
+            rc = rcs_before[i]
+            extra = 1 if (payload is a) else 0
+            if sys.getrefcount(a) > rc + extra:
+                warnings.warn(
+                    f"Method {msg.name!r} retained a reference to a shared-memory input "
+                    "array. Call .copy() on any arrays you intend to keep beyond the call.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                break
+
+        return msg.call_id, msg.reply, ok, payload, shutdown
+
+    while not stop.is_set():
+        call_id = reply = None
+        try:
+            _idle_timeout = getattr(obj, "_idle_timeout", None)
+            try:
+                call_id, reply, ok, payload, shutdown = req.get(
+                    timeout=_idle_timeout, callback=_dispatch
+                )
+            except TimeoutError:
+                if getattr(obj, "_idle_function", None) is not None:
+                    getattr(obj, obj._idle_function)()
+                continue
+            if shutdown:
+                break
+            if reply is not None:
+                repq(reply).put(_Rep(call_id, ok, payload))
+        except BaseException as e:
+            logging.error(f"Actor server caught: {type(e).__name__}{e.args}\n{traceback.format_exc()}")
+            if call_id is not None and reply is not None:
+                try:
+                    repq(reply).put(_Rep(call_id, False, (type(e).__name__, e.args, traceback.format_exc())))
+                except Exception:
+                    pass
 
 
     try: 

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -144,8 +144,8 @@ def _actor_server(pkl: bytes) -> None:
         shutdown = False
 
         # snapshot refcounts of numpy array args so we can detect retained references
-        # (only needed for zero-copy calls; deepcopy=True args are already independent)
-        arrays = [] if msg.deepcopy else [a for a in msg.args if isinstance(a, np.ndarray)]
+        # (only for zero-copy "call" requests; deepcopy=True and non-call kinds are exempt)
+        arrays = [] if (msg.deepcopy or msg.kind != "call") else [a for a in msg.args if isinstance(a, np.ndarray)]
         rcs_before = [sys.getrefcount(arrays[i]) for i in range(len(arrays))]
 
         try:

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -364,8 +364,11 @@ class _RemoteMethod:
           timeout: Seconds to wait for the result; ignored if `noreply` is True.
           noreply: If True, fire-and-forget — do not request or wait for a reply.
           deepcopy: If True (default), args are deep-copied before the method runs,
-            so retained numpy arrays are safe. Set to False for zero-copy dispatch;
-            a RuntimeWarning is emitted if any array is retained beyond the call.
+            so retained numpy arrays are safe. Set to False for zero-copy dispatch:
+            args reference shared memory and are only valid during the call —
+            do not store, return, or otherwise retain them; call `.copy()` if
+            you need to keep the data. A RuntimeWarning is emitted if a retained
+            reference is detected.
 
         Returns:
           The remote return value (when noreply=False). Returns None when noreply=True.
@@ -413,8 +416,10 @@ class Actor:
       • Remote method calls: `a.method(x)`, `a.method_async(x)`, `a.method(..., noreply=True)`
       • Zero-copy dispatch via `a.method(arr, deepcopy=False)`: skip the default
         deep-copy of args. The actor method then receives numpy arrays viewing
-        shared memory; a RuntimeWarning is emitted if any are retained beyond
-        the call.
+        shared memory — they are only valid during the call. Do not store, return,
+        or otherwise retain them (the underlying buffer is reused once the call
+        returns); call `arr.copy()` if you need to keep the data. A
+        RuntimeWarning is emitted if a retained reference is detected.
       • Jupyter tab completion: `__dir__` merges local + remote names
 
     Args:

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import sys
@@ -46,6 +47,7 @@ class _Req:
     name: str
     args: tuple
     kwargs: dict
+    deepcopy: bool = True
 
 
 @dataclass
@@ -142,7 +144,8 @@ def _actor_server(pkl: bytes) -> None:
         shutdown = False
 
         # snapshot refcounts of numpy array args so we can detect retained references
-        arrays = [a for a in msg.args if isinstance(a, np.ndarray)]
+        # (only needed for zero-copy calls; deepcopy=True args are already independent)
+        arrays = [] if msg.deepcopy else [a for a in msg.args if isinstance(a, np.ndarray)]
         rcs_before = []
         for _, a in enumerate(arrays):
             rcs_before.append(sys.getrefcount(a))
@@ -153,7 +156,9 @@ def _actor_server(pkl: bytes) -> None:
             elif msg.kind == "ping":
                 payload = time.time()
             elif msg.kind == "call":
-                payload = getattr(obj, msg.name)(*msg.args, **msg.kwargs)
+                call_args = copy.deepcopy(msg.args) if msg.deepcopy else msg.args
+                call_kwargs = copy.deepcopy(msg.kwargs) if msg.deepcopy else msg.kwargs
+                payload = getattr(obj, msg.name)(*call_args, **call_kwargs)
             elif msg.kind == "getattr":
                 payload = getattr(obj, msg.name)
             elif msg.kind == "setattr":
@@ -350,6 +355,7 @@ class _RemoteMethod:
         *args,
         timeout: Optional[float] = None,
         noreply: bool = False,
+        deepcopy: bool = True,
         _ensure_open=False,
         **kwargs,
     ):
@@ -359,6 +365,9 @@ class _RemoteMethod:
           *args, **kwargs: Forwarded to the remote method.
           timeout: Seconds to wait for the result; ignored if `noreply` is True.
           noreply: If True, fire-and-forget — do not request or wait for a reply.
+          deepcopy: If True (default), args are deep-copied before the method runs,
+            so retained numpy arrays are safe. Set to False for zero-copy dispatch;
+            a RuntimeWarning is emitted if any array is retained beyond the call.
 
         Returns:
           The remote return value (when noreply=False). Returns None when noreply=True.
@@ -375,6 +384,7 @@ class _RemoteMethod:
             args,
             kwargs,
             expect_reply=not noreply,
+            deepcopy=deepcopy,
         )
         if noreply:
             return None
@@ -453,10 +463,11 @@ class Actor:
         kwargs: dict,
         *,
         expect_reply: bool = True,
+        deepcopy: bool = True,
     ) -> str:
         cid = uuid.uuid4().hex
         reply = self._rep._base if expect_reply else None
-        self._req.put(_Req(cid, reply, kind, name, args, kwargs))
+        self._req.put(_Req(cid, reply, kind, name, args, kwargs, deepcopy=deepcopy))
         return cid
 
     # --- dynamic attribute/method resolution ---

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -146,9 +146,7 @@ def _actor_server(pkl: bytes) -> None:
         # snapshot refcounts of numpy array args so we can detect retained references
         # (only needed for zero-copy calls; deepcopy=True args are already independent)
         arrays = [] if msg.deepcopy else [a for a in msg.args if isinstance(a, np.ndarray)]
-        rcs_before = []
-        for _, a in enumerate(arrays):
-            rcs_before.append(sys.getrefcount(a))
+        rcs_before = [sys.getrefcount(arrays[i]) for i in range(len(arrays))]
 
         try:
             if msg.kind == "shutdown":
@@ -191,10 +189,9 @@ def _actor_server(pkl: bytes) -> None:
             payload = (type(e).__name__, e.args, traceback.format_exc())
 
         # warn if the user method retained a reference to a shared-memory-backed array
-        for i, a in enumerate(arrays):
-            rc = rcs_before[i]
-            extra = 1 if (payload is a) else 0
-            if sys.getrefcount(a) > rc + extra:
+        for i in range(len(arrays)):
+            extra = 1 if (payload is arrays[i]) else 0
+            if sys.getrefcount(arrays[i]) > rcs_before[i] + extra:
                 warnings.warn(
                     f"Method {msg.name!r} retained a reference to a shared-memory input "
                     "array. Call .copy() on any arrays you intend to keep beyond the call.",

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -143,11 +143,6 @@ def _actor_server(pkl: bytes) -> None:
         payload = None
         shutdown = False
 
-        # snapshot refcounts of numpy array args so we can detect retained references
-        # (only for zero-copy "call" requests; deepcopy=True and non-call kinds are exempt)
-        arrays = [] if (msg.deepcopy or msg.kind != "call") else [a for a in msg.args if isinstance(a, np.ndarray)]
-        rcs_before = [sys.getrefcount(arrays[i]) for i in range(len(arrays))]
-
         try:
             if msg.kind == "shutdown":
                 shutdown = True
@@ -156,7 +151,22 @@ def _actor_server(pkl: bytes) -> None:
             elif msg.kind == "call":
                 call_args = copy.deepcopy(msg.args) if msg.deepcopy else msg.args
                 call_kwargs = copy.deepcopy(msg.kwargs) if msg.deepcopy else msg.kwargs
+                if not msg.deepcopy:
+                    all_vals = (*msg.args, *msg.kwargs.values())
+                    arrays = [a for a in all_vals if isinstance(a, np.ndarray)]
+                    rcs_before = [sys.getrefcount(arrays[i]) for i in range(len(arrays))]
                 payload = getattr(obj, msg.name)(*call_args, **call_kwargs)
+                if not msg.deepcopy:
+                    for i in range(len(arrays)):
+                        extra = 1 if (payload is arrays[i]) else 0
+                        if sys.getrefcount(arrays[i]) > rcs_before[i] + extra:
+                            warnings.warn(
+                                f"Method {msg.name!r} retained a reference to a shared-memory "
+                                "input array. Call .copy() on any arrays you intend to keep beyond the call.",
+                                RuntimeWarning,
+                                stacklevel=2,
+                            )
+                            break
             elif msg.kind == "getattr":
                 payload = getattr(obj, msg.name)
             elif msg.kind == "setattr":
@@ -187,18 +197,6 @@ def _actor_server(pkl: bytes) -> None:
             logging.error(f"Actor server caught: {type(e).__name__}{e.args}\n{traceback.format_exc()}")
             ok = False
             payload = (type(e).__name__, e.args, traceback.format_exc())
-
-        # warn if the user method retained a reference to a shared-memory-backed array
-        for i in range(len(arrays)):
-            extra = 1 if (payload is arrays[i]) else 0
-            if sys.getrefcount(arrays[i]) > rcs_before[i] + extra:
-                warnings.warn(
-                    f"Method {msg.name!r} retained a reference to a shared-memory input "
-                    "array. Call .copy() on any arrays you intend to keep beyond the call.",
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-                break
 
         return msg.call_id, msg.reply, ok, payload, shutdown
 

--- a/dejaq/remote.py
+++ b/dejaq/remote.py
@@ -170,7 +170,10 @@ def _actor_server(pkl: bytes) -> None:
             elif msg.kind == "getattr":
                 payload = getattr(obj, msg.name)
             elif msg.kind == "setattr":
-                setattr(obj, msg.name, msg.kwargs.get("value"))
+                value = msg.kwargs.get("value")
+                if msg.deepcopy:
+                    value = copy.deepcopy(value)
+                setattr(obj, msg.name, value)
                 payload = True
             elif msg.kind == "resolve":
                 try:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 from dejaq.remote import Actor, ActorDecorator
 
 class Counter:
@@ -34,3 +35,68 @@ def test_actordecorator_basic():
     greeter = Greeter("Alice")
     assert greeter.greet() == "Hello, Alice!"
     greeter.close()
+
+
+# ---- numpy / deepcopy tests ----
+
+class NumpyActor:
+    def __init__(self):
+        self._kept = []
+
+    def process(self, arr):
+        return float(arr.sum())
+
+    def mutate_then_sum(self, arr):
+        # zero the received array; with deepcopy=True this must not affect the caller's copy
+        arr[:] = 0
+        return float(arr.sum())
+
+    def retain(self, arr):
+        self._kept.append(arr)
+        return float(arr.sum())
+
+
+def test_actor_numpy_deepcopy_true_result():
+    """deepcopy=True (default): method receives correct data and produces correct result."""
+    with Actor(NumpyActor) as a:
+        arr = np.ones(100, dtype=np.float32)
+        assert a.process(arr) == 100.0
+        assert a.process(arr, deepcopy=True) == 100.0
+
+
+def test_actor_numpy_deepcopy_false_result():
+    """deepcopy=False: method produces correct result via zero-copy path."""
+    with Actor(NumpyActor) as a:
+        arr = np.ones(100, dtype=np.float32)
+        assert a.process(arr, deepcopy=False) == 100.0
+
+
+def test_actor_numpy_deepcopy_true_isolates_args():
+    """deepcopy=True: mutations inside the method do not corrupt subsequent calls."""
+    with Actor(NumpyActor) as a:
+        arr = np.ones(50, dtype=np.float32)
+        # mutate_then_sum zeros the array it receives; with deepcopy the next call
+        # must still see ones, not zeros.
+        assert a.mutate_then_sum(arr, deepcopy=True) == 0.0  # method sees copy → zeroed copy → 0
+        assert a.process(arr, deepcopy=True) == 50.0         # next call still sees original ones
+
+
+def test_actor_numpy_deepcopy_true_no_warning(capfd):
+    """deepcopy=True: retaining the array inside the method must NOT emit a RuntimeWarning."""
+    with Actor(NumpyActor) as a:
+        arr = np.ones(10, dtype=np.float32)
+        result = a.retain(arr, deepcopy=True)
+        assert result == 10.0
+    out = capfd.readouterr()
+    assert "RuntimeWarning" not in out.err
+    assert "retained" not in out.err
+
+
+def test_actor_numpy_deepcopy_false_warns_on_retention(capfd):
+    """deepcopy=False: retaining a shared-memory array must emit a RuntimeWarning."""
+    with Actor(NumpyActor) as a:
+        arr = np.ones(10, dtype=np.float32)
+        result = a.retain(arr, deepcopy=False)
+        assert result == 10.0
+    out = capfd.readouterr()
+    assert "RuntimeWarning" in out.err and "retain" in out.err

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -100,3 +100,29 @@ def test_actor_numpy_deepcopy_false_warns_on_retention(capfd):
         assert result == 10.0
     out = capfd.readouterr()
     assert "RuntimeWarning" in out.err and "retain" in out.err
+
+
+class Storage:
+    def __init__(self):
+        self.data = None
+    def get_data(self):
+        return self.data
+
+
+def test_actor_setattr_numpy_array_is_independent_of_shared_memory(capfd):
+    """Setting an actor attribute to a numpy array must store an independent copy.
+
+    If the stored value were a view into the request queue's shared memory,
+    subsequent queue activity would silently corrupt the attribute, and the
+    SharedMemory destructor in the server would raise
+    `BufferError: cannot close exported pointers exist` on shutdown.
+    """
+    original = (np.arange(100, dtype=np.float32) * 7.0)
+    with Actor(Storage) as a:
+        a.data = original
+        retrieved = a.get_data()
+        np.testing.assert_array_equal(retrieved, original)
+    # On clean shutdown the server's SharedMemory should release cleanly.
+    out = capfd.readouterr()
+    assert "BufferError" not in out.err
+    assert "cannot close exported pointers" not in out.err


### PR DESCRIPTION
## Summary

- Replaces `deepcopy` in `req.get()` with a `callback`-based dispatch (`_dispatch` closure) so the actor method runs while shared memory is still pinned — no copy needed for zero-copy paths
- After the method returns, compares `sys.getrefcount` snapshots to detect numpy arrays from `msg.args` that were retained beyond the call; emits a `RuntimeWarning` naming the offending method
- Adds `import warnings` and `import numpy as np` to `remote.py`

## How retention detection works

Before dispatching, we snapshot `sys.getrefcount` for each numpy array argument using `enumerate` (critical: `enumerate` and `zip` add different numbers of internal references, so measurement and check must use the same loop construct). After the method returns, we compare — any count higher than the baseline (plus 1 if the return value *is* the same array object) means the method held on to a reference:

```python
arrays = [a for a in msg.args if isinstance(a, np.ndarray)]
rcs_before = []
for _, a in enumerate(arrays):
    rcs_before.append(sys.getrefcount(a))

# ... dispatch method ...

for i, a in enumerate(arrays):
    rc = rcs_before[i]
    extra = 1 if (payload is a) else 0
    if sys.getrefcount(a) > rc + extra:
        warnings.warn(..., RuntimeWarning)
        break
```

## Test plan

- [ ] Clean method (e.g. `return arr.sum()`) produces no warning
- [ ] Retaining method (e.g. `self._kept.append(arr)`) produces `RuntimeWarning` naming the method
- [ ] All existing actor functionality (ping, getattr, setattr, resolve, dir, shutdown) still works

https://claude.ai/code/session_01S3pZJHih4Pu6D3afUodE6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3pZJHih4Pu6D3afUodE6Y)_